### PR TITLE
Reintroduce a `Resource#response` method that contains the original HTTP response of the API call.

### DIFF
--- a/lib/pfs/api/accounts_service.rb
+++ b/lib/pfs/api/accounts_service.rb
@@ -5,7 +5,7 @@ module PFS
     class AccountsService < Service
       def balance(account_id)
         response = client.get("/Account/#{account_id}/Balance")
-        Resources::Accounts::Balance.new(response.body[:data])
+        Resources::Accounts::Balance.new(response, response.body[:data])
       end
 
       def credit(account_id, currency, amount, fee_code = "**API", description = "Deposit To Card API")
@@ -16,7 +16,7 @@ module PFS
           transactionDescription: description,
         }
         response = client.post("/Account/#{account_id}/Balance/Credit", attributes)
-        Resources::Accounts::BalanceCredit.new(response.body[:data])
+        Resources::Accounts::BalanceCredit.new(response, response.body[:data])
       end
     end
   end

--- a/lib/pfs/api/authentication_service.rb
+++ b/lib/pfs/api/authentication_service.rb
@@ -9,7 +9,7 @@ module PFS
           password: password,
         }
         response = client.post("/Auth/Jwt", attributes, options)
-        Resources::Authentication::Token.new(response.body[:data])
+        Resources::Authentication::Token.new(response, response.body[:data])
       end
     end
   end

--- a/lib/pfs/api/statements_service.rb
+++ b/lib/pfs/api/statements_service.rb
@@ -5,7 +5,7 @@ module PFS
         response = client.get(
           "/BankPayment/#{account_id}/StatementById?statementitemid=#{statement_id}&InwardOutward=#{inward_outward}&Processor=#{processor}"
         )
-        Resources::Statements::Statement.new(response.body.dig(:data, :transaction))
+        Resources::Statements::Statement.new(response, response.body.dig(:data, :transaction))
       end
     end
   end

--- a/lib/pfs/api/transactions_service.rb
+++ b/lib/pfs/api/transactions_service.rb
@@ -6,7 +6,7 @@ module PFS
       def history(account_id:, start_date:, end_date:)
         response = client.get("/Account/#{account_id}/Transactions?StartDate=#{start_date}&EndDate=#{end_date}")
         transactions_raw = response.body.dig(:data, :transactions)
-        Resources::Transactions::Transactions.new(response.body.dig(:data, :transactions))
+        Resources::Transactions::Transactions.new(response, response.body.dig(:data, :transactions))
       end
     end
   end

--- a/lib/pfs/api/transfers_service.rb
+++ b/lib/pfs/api/transfers_service.rb
@@ -16,7 +16,7 @@ module PFS
         data[:isinstant] = true if options[:instant]
         data[:reference] = options[:reference] if options[:reference]
         response = client.post("/BankPayment/#{account_id}/OneOffPayment", data, options)
-        Resources::Transfers::Transfer.new(response.body[:data])
+        Resources::Transfers::Transfer.new(response, response.body[:data])
       end
     end
   end

--- a/lib/pfs/resources/authentication/token.rb
+++ b/lib/pfs/resources/authentication/token.rb
@@ -10,8 +10,8 @@ module PFS
         alias access_token accessToken
         alias expires_in expiresIn
 
-        def initialize(response)
-          super(response)
+        def initialize(response, attributes = {})
+          super(response, attributes)
           @expires_on = Time.now + expires_in
         end
 

--- a/lib/pfs/resources/base.rb
+++ b/lib/pfs/resources/base.rb
@@ -3,7 +3,10 @@
 module PFS
   module Resources
     class Base
-      def initialize(attributes = {})
+      attr_reader :response
+
+      def initialize(response, attributes = {})
+        @response = response
         attributes.each do |key, value|
           m = "#{key}=".to_sym
           send(m, value) if respond_to?(m)

--- a/lib/pfs/resources/collection.rb
+++ b/lib/pfs/resources/collection.rb
@@ -4,10 +4,12 @@ module PFS
   module Resources
     class Collection
       include Enumerable
+      attr_reader :response
 
-      def initialize(item_klass, attributes_collection = [])
+      def initialize(response, item_klass, attributes_collection = [])
+        @response = response
         @attributes_collection = attributes_collection
-        @items = attributes_collection.map { |attributes_item| item_klass.new(attributes_item) }
+        @items = attributes_collection.map { |attributes_item| item_klass.new(nil, attributes_item) }
       end
 
       def each(&block)

--- a/lib/pfs/resources/transactions/transactions.rb
+++ b/lib/pfs/resources/transactions/transactions.rb
@@ -4,8 +4,8 @@ module PFS
   module Resources
     module Transactions
       class Transactions < Collection
-        def initialize(attributes_collection)
-          super(Transaction, attributes_collection)
+        def initialize(response, attributes_collection)
+          super(response, Transaction, attributes_collection)
         end
       end
     end


### PR DESCRIPTION
This PR reintroduces a `Resource#response` method that contains the initial HTTP response of the API call that generated the resource. This method has been in use for some time in our code for audit reasons and may be removed later, but to make the extraction just a drop-in, I'm reintroducing the original behaviour. 
