### PR TITLE
Refactoring error handler to improve the error taxonomy

### DIFF
--- a/lib/pfs.rb
+++ b/lib/pfs.rb
@@ -1,5 +1,6 @@
 
 require "pfs/version"
+require "pfs/error"
 require "pfs/client"
 module PFS
 end

--- a/lib/pfs/client.rb
+++ b/lib/pfs/client.rb
@@ -87,23 +87,12 @@ module PFS
     def handle_request_error(error)
       case error
       when Faraday::ClientError
-        if error.response
-          handle_error_response(error)
-        else
-          handle_network_error(error)
-        end
+        raise ClientError, error
+      when Faraday::ServerError
+        raise ServerError, error
       else
-        raise error
+        raise Error, error
       end
-    end
-
-    def handle_error_response(error)
-      puts "ERROR #{error.response}"
-      raise error
-    end
-
-    def handle_network_error(error)
-      raise error
     end
 
     def login_path?(path)

--- a/lib/pfs/error.rb
+++ b/lib/pfs/error.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module PFS
+    class Error < StandardError
+      attr_reader :wrapped_error, :status, :response
+  
+      def initialize(error)
+        @wrapped_error = error
+        @response = @wrapped_error.response if @wrapped_error.respond_to?(:response)
+        @status = structured_response[:status]
+        super(error_message)
+      end
+  
+      private def error_message
+        return @wrapped_error unless @response
+  
+        wrapped_error_description = "#{@wrapped_error.class}: #{@wrapped_error}"
+        response_description = "Status: #{structured_response[:status]} - Response: '#{structured_response[:body]}'"
+        "#{response_description} (#{wrapped_error_description})"
+      end
+  
+      private def structured_response
+        return {} unless @response
+        return @response if @response.is_a?(Hash)
+  
+        {
+          status: @response.status,
+          body: @response.body,
+        }
+      end
+    end
+  
+    class ClientError < Error
+    end
+  
+    class ServerError < Error
+    end
+  end

--- a/spec/pfs/api/statements_service_spec.rb
+++ b/spec/pfs/api/statements_service_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe PFS::API::StatementsService do
                            inward_outward: inward_outward,
                            processor: processor)
         end
-        expected.to raise_error(Faraday::Error)
+        expected.to raise_error(PFS::ClientError)
       end
     end
   end
@@ -113,7 +113,7 @@ RSpec.describe PFS::API::StatementsService do
                            inward_outward: inward_outward,
                            processor: processor)
         end
-        expected.to raise_error(Faraday::Error)
+        expected.to raise_error(PFS::ClientError)
       end
     end
   end

--- a/spec/pfs/api/transactions_service_spec.rb
+++ b/spec/pfs/api/transactions_service_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe PFS::API::TransactionsService do
                             start_date: start_date,
                             end_date: end_date)
         end
-        expected.to raise_error(Faraday::Error)
+        expected.to raise_error(PFS::ClientError)
       end
     end
   end


### PR DESCRIPTION
Applying the same error taxonomy than https://github.com/devengoapp/modulr-ruby/pull/33