### PR TITLE
Attributes collection as nil value

### DIFF
--- a/lib/pfs/resources/collection.rb
+++ b/lib/pfs/resources/collection.rb
@@ -8,7 +8,7 @@ module PFS
 
       def initialize(response, item_klass, attributes_collection = [])
         @response = response
-        @attributes_collection = attributes_collection
+        @attributes_collection = attributes_collection || []
         @items = attributes_collection.map { |attributes_item| item_klass.new(nil, attributes_item) }
       end
 

--- a/spec/pfs/resources/collection_spec.rb
+++ b/spec/pfs/resources/collection_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe PFS::Resources::Collection do
+  let(:response) { { data: [ { id: 1 }, { id: 2 }] }.to_json }
+  let(:item_klass) { double }
+
+  before do
+    allow(item_klass).to receive(:new)
+  end
+
+  context "with attributes_collection" do
+    subject(:collection) { PFS::Resources::Collection.new(response, item_klass, [{ id: 1 }, { id: 2 }]) }
+
+    it "initialize object collection with test attributes" do
+      expect(collection.response).to eql(response)
+      expect(item_klass).to have_received(:new).with(nil, { id: 1 }).once
+      expect(item_klass).to have_received(:new).with(nil, { id: 2 }).once
+    end
+  end
+
+  context "without attributes_collection" do
+    subject(:collection) { PFS::Resources::Collection.new(response, item_klass) }
+
+    it "initialize object collection with nil attributes" do
+      expect(collection.response).to eql(response)
+      expect(item_klass).not_to have_received(:new)
+    end
+  end
+end


### PR DESCRIPTION
What if a service response returns a nullable value instead of any other expected result?

```ruby
      def initialize(response, item_klass, attributes_collection = [])
        @response = response
        @attributes_collection = attributes_collection
        @items = attributes_collection.map { |attributes_item| item_klass.new(nil, attributes_item) }
      end
```

It allows to pass nil as value and will be trying to iterate over it later, crashing process.
As a valid approach we can handle it in several ways:

1. `@attributes_collection = attributes_collection || []`
2. `@items = attributes_collection&.map { |attributes_item| item_klass.new(nil, attributes_item) }`