### PR TITLE
Ensure the collection creation for nil attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ Gemfile.lock
 
 # rspec failure tracking
 .rspec_status
+
+/.vscode/

--- a/lib/pfs/resources/collection.rb
+++ b/lib/pfs/resources/collection.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module PFS
   module Resources
     class Collection
@@ -8,8 +6,9 @@ module PFS
 
       def initialize(response, item_klass, attributes_collection = [])
         @response = response
-        @attributes_collection = attributes_collection
-        @items = attributes_collection.map { |attributes_item| item_klass.new(nil, attributes_item) }
+        @items = Array(attributes_collection).map { |attributes_item|
+          item_klass.new(nil, attributes_item)
+        }
       end
 
       def each(&block)


### PR DESCRIPTION
If the _attributes_collection_ argument is an **explicit** nil, we can end up raising a `NoMethodError: undefined method each for nil:NilClass` error.

This change ensures that @items will always be an array, even if attributes_collection is nil or not provided. As a result, calling each on @items will not raise an exception, as each is a valid method on an empty array.

https://apidock.com/ruby/Kernel/Array/instance